### PR TITLE
Issue 15: Fix bank/sector erase for non-zero app start in FLM

### DIFF
--- a/CMSIS/Flash/STM32U5xx/FlashPrg.c
+++ b/CMSIS/Flash/STM32U5xx/FlashPrg.c
@@ -427,8 +427,8 @@ int Init (unsigned long adr, unsigned long clk, unsigned long fnc)
 
   while (*pFlashSR & FLASH_SR_BSY) NOP();                /* Wait until operation is finished */
 
-  gFlashBase = adr;
   gFlashSize = (M32(FLASHSIZE_BASE) & 0x0000FFFF) << 10;
+  gFlashBase = (adr & ~(gFlashSize - 1u));
 #endif /* FLASH_MEM */
 
 #if defined FLASH_OPT


### PR DESCRIPTION
This PR fixes an issue in the STM32U5xx flash programming algorithm (FLM) where sector erase / bank selection becomes incorrect when the flashing region does not start at the flash base address (0x08000000). This commonly happens when a bootloader is already present and the application is flashed at an offset (e.g. 0x08030000).

In practice, the problem becomes visible when the application image is large enough to cross the bank boundary (e.g. beyond 0x08100000 on 2 MB devices).

The root cause is that GetFlashBankNum() performs incorrect bank/sector calculations when gFlashBase is not the true flash base.

#### Before:
```
Initializing [DONE] Product license
Initializing [DONE] CMSIS Packages
Initializing [DONE] Initializing database
Initializing [DONE] Debug Server
Initializing [        =========                 ] Initialising Debugger
Stopping running target Cortex-M33 on connection
Initializing [          =========               ] Initialising Debugger
Execution stopped in Non-secure Privileged Thread mode at 0x0809842C
Initializing [DONE] Initialising Debugger
0x0809842C   B        {pc}-10 ; 0x8098422
Connected to stopped target Cortex-M33
Starting flash programming...
Target has been reset
Execution stopped in Non-secure Privileged Thread mode due to a breakpoint or watchpoint: 0x08000314
0x08000314   LDR      r0,[pc,#40] ; [0x8000340] = 0x8000359
Mapping segment 0x08030000 ~ 0x081063F8 (size 0xD63F8)
Erasing [93%] Flash Progress: Erased 819200 bytes
Writing [97%] Flash Progress: Wrote 851968 bytes

Disconnected from stopped target Cortex-M33
(ERROR:CLI0037): Debug session launch failed
Flash programming failed: Failed to program 400 bytes at 0x08100000: 1
(Client CLI disconnected from localhost:49604)
Terminating Arm Debugger server on by-VirtualBox/127.0.1.1:55000

Flash failed
```
#### Alter:
```
Initializing [DONE] Product license
Initializing [DONE] CMSIS Packages
Initializing [DONE] Initializing database
Initializing [DONE] 
Initializing [  =========                       ] Initialising Debugger
Stopping running target Cortex-M33 on connection
Initializing [    =========                     ] Initialising Debugger
Execution stopped in Non-secure Handler mode due to a breakpoint or watchpoint: 0x08046614
Initializing [DONE] Initialising Debugger
0x08046614   B        {pc} ; 0x8046614
Connected to stopped target Cortex-M33
Starting flash programming...
Target has been reset
Execution stopped in Non-secure Privileged Thread mode due to a breakpoint or watchpoint: 0x08000314
0x08000314   LDR      r0,[pc,#40] ; [0x8000340] = 0x8000359
Mapping segment 0x08030000 ~ 0x081063F8 (size 0xD63F8)
Erasing [93%] Flash Progress: Erased 819200 bytes
Writing [99%] Flash Progress: Wrote 872448 bytes
Verifying [99%] Flash Progress: Verified 865280 bytes

Flashing complete!
```



